### PR TITLE
Renaming Table of Content to Content

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A curated list of awesome Node.js Security related resources.
 </div>
 <br/>
 
-# Table of Contents
+# Contents
 
 - [Tools](#projects)
   - [Web Framework Hardening](#web-framework-hardening)


### PR DESCRIPTION
To comply with the awesome-list requirements.
`Should be named Contents, not Table of Contents.`