### PR TITLE
docs: add 'A Tale of (prototype) Poisoining' in the Articles section

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Follow-up notes:
  - [Why npm lockfiles can be a security blindspot for injecting malicious modules](https://snyk.io/blog/why-npm-lockfiles-can-be-a-security-blindspot-for-injecting-malicious-modules/)
  - [GitHub Actions to securely publish npm packages](https://snyk.io/blog/github-actions-to-securely-publish-npm-packages/)
  - [Top 11 Node.js security best practices | Sqreen.com](https://blog.sqreen.com/nodejs-security-best-practices/)
+ - [A Tale of (prototype) Poisoning](https://www.fastify.io/docs/latest/Guides/Prototype-Poisoning/)
 
 ## Research Papers
  - [Deep dive into Visual Studio Code extension security vulnerabilities](https://snyk.io/blog/visual-studio-code-extension-security-vulnerabilities-deep-dive)


### PR DESCRIPTION
I think this article from the Fastify.io doc (originally written by Eran Hammer) has it place in the Articles section. The first time I read it I found it quite informative (while the concept was still vague to me).

Also had the feeling the repo was lacking educational resources on the subject (other than tools/hardening techniques).