### PR TITLE
Added link of Node.js Developer Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A curated list of awesome Node.js Security resources.
   - [Articles](#articles)
   - [Research Papers](#research-papers)
   - [Books](#books)
+  - [Roadmaps](#roadmap)
 - [Companies](#companies)
 
 # Tools
@@ -212,6 +213,9 @@ Follow-up notes:
 - [Web Developer Security Toolbox
 ](https://leanpub.com/b/webdevelopersecuritytoolbox) - Bundled Node.js and Web Security Books.
 - [Thomas Gentilhomme](https://github.com/fraxken) book: [Become a Node.js Developer](https://github.com/fraxken/ebook_nodejs) 
+
+## Roadmaps
+  - [Node.js Developer Roadmap](#https://roadmap.sh/nodejs)
 
 # Companies
 - [Snyk](https://snyk.io) - A developer-first solution that automates finding & fixing vulnerabilities in your dependencies.


### PR DESCRIPTION
Hi Liran,

I came across your repository [awesome-nodejs-security](https://github.com/lirantal/awesome-nodejs-security) and found it to be a valuable resource for Nodejs enthusiasts.

While browsing through the repository, I noticed that it was missing links to any structured guides such as the famous ["Node.js Developer Roadmap"](https://roadmap.sh/nodejs). I took the initiative to submit a ["Pull Request"](https://github.com/lirantal/awesome-nodejs-security/pull/85) adding it in Educational section.

Thank you for your time and effort in maintaining this valuable resource :)

Best,
Mouaaz