### PR TITLE
Add reporting-api to Web Framework Hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ A curated list of awesome Node.js Security resources.
 - [blankie](https://github.com/nlf/blankie) - CSP plugin for [hapi](https://github.com/hapijs/hapi).
 - [fastify-helmet](https://github.com/fastify/fastify-helmet) - fastify-helmet helps you secure your [fastify](https://www.fastify.io/) apps by setting important security headers.
 - [nuxt-security](https://github.com/Baroshem/nuxt-security) - 🛡 Security Module for Nuxt based on OWASP Top 10 and Helmet.
+- [reporting-api](https://github.com/wille/reporting-api) - Setup and collect CSP, Reporting API v0 and v1 reports to reliabily parse them to be processed by the user
 
 ## GitHub Actions and CI/CD Security
 - [New dependencies advisor](https://github.com/marketplace/actions/new-dependencies-advisor) - GitHub Action adding comments to pull requests with package health information about newly added npm dependencies.


### PR DESCRIPTION
I want to add my package [reporting-api](https://github.com/wille/reporting-api) which handles configuration and collection of [Reporting API](https://developer.mozilla.org/en-US/docs/Web/API/Reporting_API) reports.

It supports CSP reports or any report supporting the Reporting API v0 and v1, and lets the user process the reports in a unified format.