### PR TITLE
Add releaserun - dependency EOL and CVE scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ A curated list of awesome Node.js Security resources.
 - [confused](https://github.com/visma-prodsec/confused) - Tool to check for dependency confusion vulnerabilities in multiple package management systems. See [Dependency Confusion: How I Hacked Into Apple, Microsoft and Dozens of Other Companies](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610) for reference on the reasoning for this tool.
 - [nodejs-cve-checker](https://github.com/nodejs/nodejs-cve-checker) - A simple tool that validates CVEs were published to NVD after a Node.js Security Release.
 - [zizmor](https://github.com/zizmorcore/zizmor) - Static analysis for GitHub Actions and CI/CD workflows.
+- [releaserun](https://github.com/Releaserun/releaserun-cli) - Scan project dependencies for end-of-life runtimes, known CVEs, and version health grades across 300+ products.
 
 ## Security Hardening
 - [hijagger](https://github.com/firefart/hijagger) - Checks all maintainers of all npm and PyPI packages for hijackable packages through domain re-registration.


### PR DESCRIPTION
Adds [releaserun](https://github.com/Releaserun/releaserun-cli) to the Vulnerabilities and Security Advisories section.

Scans dependency files (package.json, requirements.txt, go.mod, Gemfile, Cargo.toml, pom.xml) and checks each detected technology against endoflife.date and CVE databases. Returns health grades (A-F) with actionable warnings about EOL and vulnerable dependencies.

CI-friendly: `npx releaserun ci --fail-on D` exits non-zero if any dependency scores below the threshold.