### PR TITLE
Add FCaptcha to Security Hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ A curated list of awesome Node.js Security resources.
 - [is-my-node-vulnerable](https://github.com/RafaelGSS/is-my-node-vulnerable) - package that checks if your Node.js installation is vulnerable to known security vulnerabilities.
 - [@lavamoat/preinstall-always-fail](https://www.npmjs.com/package/@lavamoat/preinstall-always-fail) - npm package to assert if preinstall or postinstall scripts are running in your npm or yarn workflows.
 - [are-scripts-enabled](https://www.npmjs.com/package/are-scripts-enabled) - npm package to assert if preinstall or postinstall scripts are running in your npm or yarn workflows.
+- [FCaptcha](https://github.com/WebDecoy/FCaptcha) - Self-hosted CAPTCHA with behavioral analysis that detects bots, vision AI agents, and headless browsers. Includes Node.js server with SHA-256 proof of work.
 
 # Data Sources
 


### PR DESCRIPTION
Adds FCaptcha to the Security Hardening section. FCaptcha is a self-hosted
CAPTCHA with a Node.js server that detects bots, vision AI agents, and
headless browsers through behavioral analysis and proof of work.

- GitHub: https://github.com/WebDecoy/FCaptcha
- License: MIT
- Node.js server: `server-node/`

## Disclosure
I am the maintainer of FCaptcha.