### PR TITLE
Add @w-r-l/verify to Security Hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ A curated list of awesome Node.js Security resources.
 - [FCaptcha](https://github.com/WebDecoy/FCaptcha) - Self-hosted CAPTCHA with behavioral analysis that detects bots, vision AI agents, and headless browsers. Includes Node.js server with SHA-256 proof of work.
 - [are-scripts-enabled](https://www.npmjs.com/package/are-scripts-enabled) - npm package to assert if preinstall or postinstall scripts are running in your npm or yarn workflows.
 - [FCaptcha](https://github.com/WebDecoy/FCaptcha) - Self-hosted CAPTCHA with behavioral analysis that detects bots, vision AI agents, and headless browsers. Includes Node.js server with SHA-256 proof of work.
+- [@w-r-l/verify](https://www.npmjs.com/package/@w-r-l/verify) - Verify cryptographic integrity of WACZ web archive bundles. Checks Ed25519 signatures and RFC 3161 timestamps.
 
 # Data Sources
 


### PR DESCRIPTION
## What is @w-r-l/verify?

A CLI and library for verifying the cryptographic integrity of [WACZ](https://specs.webrecorder.net/wacz/1.1.1/) web archive bundles. It checks:

- **Ed25519 signatures** on the archive hash
- **RFC 3161 timestamps** for proof-of-existence

It's useful for anyone working with web evidence preservation, legal archiving, or forensic capture of web pages.

- **npm**: https://www.npmjs.com/package/@w-r-l/verify
- **Source**: https://github.com/benpeter/web-resource-ledger/tree/main/packages/verify

Added to the **Security Hardening** section (end of list, per contributing guidelines).