### PR TITLE
feat: add trustdep to Vulnerabilities and Security Advisories

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ A curated list of awesome Node.js Security resources.
 - [nodejs-cve-checker](https://github.com/nodejs/nodejs-cve-checker) - A simple tool that validates CVEs were published to NVD after a Node.js Security Release.
 - [zizmor](https://github.com/zizmorcore/zizmor) - Static analysis for GitHub Actions and CI/CD workflows.
 - [releaserun](https://github.com/Releaserun/releaserun-cli) - Scan project dependencies for end-of-life runtimes, known CVEs, and version health grades across 300+ products.
+- [trustdep](https://github.com/ali-bingul/trustdep) - CLI to scan npm packages for supply chain risks: typosquatting, maintainer changes, phantom dependencies, malicious install scripts, and known CVEs via OSV.dev.
 
 ## Security Hardening
 - [hijagger](https://github.com/firefart/hijagger) - Checks all maintainers of all npm and PyPI packages for hijackable packages through domain re-registration.


### PR DESCRIPTION
trustdep is a CLI tool that scans npm packages for supply chain risks before installation:

- Typosquatting detection (Levenshtein + phonetic similarity against top 10k packages)
- Maintainer/publisher change detection
- Phantom dependency analysis
- Malicious install script pattern detection  
- Known CVEs via OSV.dev integration
- Download spike detection

npm: https://npmjs.com/package/trustdep
GitHub: https://github.com/ali-bingul/trustdep

Fits in the "Vulnerabilities and Security Advisories" section.