### PR TITLE
feat: add cve-lite-cli to Vulnerabilities and Security Advisories

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ A curated list of awesome Node.js Security resources.
 - [zizmor](https://github.com/zizmorcore/zizmor) - Static analysis for GitHub Actions and CI/CD workflows.
 - [releaserun](https://github.com/Releaserun/releaserun-cli) - Scan project dependencies for end-of-life runtimes, known CVEs, and version health grades across 300+ products.
 - [CVE PoC Search](https://labs.jamessawyer.co.uk/cves/) - Search public GitHub proof-of-concept repositories by CVE identifier.
+- [cve-lite-cli](https://github.com/OWASP/cve-lite-cli) - OWASP Lab Project that scans npm, pnpm, Yarn, and Bun lockfiles locally against the OSV database, classifies findings as direct or transitive, and generates copy-and-run upgrade commands.
 
 ## Security Hardening
 - [hijagger](https://github.com/firefart/hijagger) - Checks all maintainers of all npm and PyPI packages for hijackable packages through domain re-registration.


### PR DESCRIPTION
Adds [cve-lite-cli](https://github.com/OWASP/cve-lite-cli) to the Vulnerabilities and Security Advisories section.

CVE Lite CLI is an OWASP Lab Project that scans npm, pnpm, Yarn, and Bun lockfiles locally against the OSV database. It classifies findings as direct or transitive and generates copy-and-run upgrade commands - no account or cloud connectivity required.

- No duplicate - cve-lite-cli is not currently listed
- Added at end of section
- Description starts with capital and ends with period
- Single suggestion