### PR TITLE
Add supply-chain-guard to Vulnerabilities and Security Advisories 🤖🤖🤖

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ A curated list of awesome Node.js Security resources.
 - [releaserun](https://github.com/Releaserun/releaserun-cli) - Scan project dependencies for end-of-life runtimes, known CVEs, and version health grades across 300+ products.
 - [CVE PoC Search](https://labs.jamessawyer.co.uk/cves/) - Search public GitHub proof-of-concept repositories by CVE identifier.
 - [cve-lite-cli](https://github.com/OWASP/cve-lite-cli) - OWASP Lab Project that scans npm, pnpm, Yarn, and Bun lockfiles locally against the OSV database, classifies findings as direct or transitive, and generates copy-and-run upgrade commands.
+- [supply-chain-guard](https://github.com/homeofe/supply-chain-guard) - CLI and MCP server that scans npm dependencies for malware campaigns (GlassWorm, Shai-Hulud), typosquats and malicious install hooks before installation, with SLSA provenance grading and CycloneDX SBOM output.
 
 ## Security Hardening
 - [hijagger](https://github.com/firefart/hijagger) - Checks all maintainers of all npm and PyPI packages for hijackable packages through domain re-registration.


### PR DESCRIPTION
Adds [supply-chain-guard](https://github.com/homeofe/supply-chain-guard), an Apache-2.0 CLI + MCP server that scans npm dependencies for malware campaigns (GlassWorm, Shai-Hulud), typosquats and malicious install hooks before installation, with SLSA provenance grading and CycloneDX SBOM output. Fully offline/local.

Added to the end of the **Vulnerabilities and Security Advisories** section, one entry, capitalized and ending with a period per CONTRIBUTING.