### PR TITLE
Add Extuno to Static Code Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ A curated list of awesome Node.js Security resources.
 - [Bearer](https://github.com/Bearer/bearer) - A CLI tool to find and help you fix security and privacy risks in your code according to OWASP Top 10.
 - [GuardDog](https://github.com/DataDog/guarddog) - GuardDog is a CLI tool to Identify malicious PyPI and npm packages
 - [repolyze](https://github.com/lirantal/repolyze) - Analyze a git source code repository for health signals and project vitals
+- [Extuno](https://extuno.com) - Scans npm packages and browser extensions for supply chain risk, diffing every published version to catch a package that turns malicious in an update, using static rules, source review and dynamic execution in an isolated microVM. Has a free tier.
 
 ## Dynamic Application Security Testing
 


### PR DESCRIPTION
Adds Extuno to `Static Code Analysis`, at the end of the list per the contribution guidelines.

**Why here.** It sits next to `GuardDog` in scope: identifying malicious npm and PyPI packages rather than auditing for known CVEs. The angle it adds is the version dimension. It analyses every published version of a package and diffs them, which is what surfaces the case this list documents repeatedly in the protestware and incident sections: a package that was fine for years and turns hostile in one release. Analysis is static rules plus source review plus execution in an isolated microVM, so install-time and import-time behaviour is observed rather than inferred.

Browser extensions are covered by the same engine, which is relevant here because the npm and extension ecosystems keep sharing attack patterns.

**Disclosure.** I run the service. There is a free tier and the malicious-package database is free with no account; the deeper analysis is metered. The list already carries commercially backed entries such as Snyk and cspscanner, so I have stated the model plainly rather than leaving it implied.

The CLI side is open source and MIT (https://github.com/Extuno/extuno-cli), but it wraps `pip` rather than npm, so the platform entry is the one that belongs in this list.
